### PR TITLE
Capitalised the first letter in Instagram

### DIFF
--- a/Socials.yml
+++ b/Socials.yml
@@ -81,7 +81,7 @@ Hyves:
 identi.ca:
   - identi.ca
 
-instagram:
+Instagram:
   - instagram.com
   - l.instagram.com
 


### PR DESCRIPTION
A tiny one, based on Instagram's [brand guidelines](https://en.instagram-brand.com/):

> Keep the letter "I" in Instagram capitalized and in same font size and style as the content surrounding it.

