### PR TITLE
Update Mail.ru search engine

### DIFF
--- a/SearchEngines.yml
+++ b/SearchEngines.yml
@@ -1446,7 +1446,9 @@ Mailru:
       - UTF-8
       - windows-1251
     hiddenkeyword:
-      - '/.*/'
+      - '/redir\?.*redir=.*/'
+      - '/^$/'
+      - '/'
 Mamma:
   - 
     urls:

--- a/SearchEngines.yml
+++ b/SearchEngines.yml
@@ -1446,7 +1446,9 @@ Mailru:
       - UTF-8
       - windows-1251
     hiddenkeyword:
-      - '/redir\?.*redir=.*/'
+      - '/redir\?.*redir=.*/',
+      - '/.*/'
+      - '/'
 Mamma:
   - 
     urls:

--- a/SearchEngines.yml
+++ b/SearchEngines.yml
@@ -1446,9 +1446,7 @@ Mailru:
       - UTF-8
       - windows-1251
     hiddenkeyword:
-      - '/redir\?.*redir=.*/'
       - '/.*/'
-      - '/'
 Mamma:
   - 
     urls:

--- a/SearchEngines.yml
+++ b/SearchEngines.yml
@@ -1446,7 +1446,7 @@ Mailru:
       - UTF-8
       - windows-1251
     hiddenkeyword:
-      - '/redir\?.*redir=.*/',
+      - '/redir\?.*redir=.*/'
       - '/.*/'
       - '/'
 Mamma:


### PR DESCRIPTION
Added hiddenkeyword regexes for empty path.
At the moment Matomo does not recognize Mail.ru as search engine.