### PR TITLE
remove incorrect hiddenkeyword for startpage

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ SearchEngine:
 
 The configuration above would allow an empty keyword for `searchengine.com`, `searchengine.com/` and `searchengine.com/search`
 
+If `hiddenkeyword` is not specified, it defaults to `['/^$/', '/']`
+
 ### charsets
 
 Charsets can be defined if search engines are using charsets other than UTF-8. The provided charset will be used to convert any detected search keyword to UTF-8.

--- a/SearchEngines.yml
+++ b/SearchEngines.yml
@@ -1355,8 +1355,6 @@ IxQuick:
     params:
       - query
     backlink: 'do/asearch?query={k}'
-    hiddenkeyword:
-      - '/do/asearch'
 Jungle Key:
   - 
     urls:
@@ -2032,8 +2030,6 @@ StartPage:
     params:
       - query
     backlink: 'do/asearch?query={k}'
-    hiddenkeyword:
-      - '/do/asearch'
 Startpagina (Google):
   - 
     urls:


### PR DESCRIPTION
https://github.com/matomo-org/matomo/pull/16747 only solves half of https://github.com/matomo-org/matomo/issues/16742

for the default to work, the incorrect `hiddenkeyword` has to be removed.