### PR TITLE
add Brave Search

### DIFF
--- a/SearchEngines.yml
+++ b/SearchEngines.yml
@@ -440,6 +440,13 @@ Bluewin:
       - searchTerm
       - q
     backlink: 'v2/index.php?q={k}'
+Brave:
+  -
+    urls:
+      - search.brave.com
+    params:
+      - q
+    backlink: 'search?q={k}'
 Canoe.ca:
   -
     urls:


### PR DESCRIPTION
reported in https://forum.matomo.org/t/breave-search-support/42377

https://search.brave.com/ was published a few days ago I think

I didn't test it, but the URL schema seems straightforward.