### PR TITLE
Add missing ChatGPT "params"

### DIFF
--- a/SearchEngines.yml
+++ b/SearchEngines.yml
@@ -480,6 +480,7 @@ ChatGPT:
   -
     urls:
       - chat.openai.com
+    params: []
     hiddenkeyword:
       - '/^$/'
       - '/'


### PR DESCRIPTION
The new entry for ChatGPT provided by #100 has missing `params` and results in a notice+warning when a ChatGPT referrer is parsed:

```
PHP Notice: Undefined index: params in /srv/matomo/plugins/Referrers/SearchEngine.php on line 231
PHP Warning: Invalid argument supplied for foreach() in /srv/matomo/plugins/Referrers/SearchEngine.php on line 283
```

Eventually, the referrer parsing should handle those problems more gracefully. A CI job to verify all entries have a consistent structure could also help here. But in the meantime, this should keep the logs happy.