### PR TITLE
Add Swisscows as search engine

### DIFF
--- a/SearchEngines.yml
+++ b/SearchEngines.yml
@@ -2136,6 +2136,13 @@ Surf Canyon:
       - surfcanyon.com
     params:
       - q
+Swisscows:
+  -
+    urls:
+      - swisscows.com
+    params:
+      - query
+    backlink: 'web?query={k}'
 T-Online:
   -
     urls:


### PR DESCRIPTION
@sgiehl I hope the PR is okay, otherwise, feel free to make changes.

From https://swisscows.com/opensearch.xml this is the correct way, but it redirects to `en` for English and it uses multiple languages:
```
https://swisscows.com/en/web?query=test
https://swisscows.com/de/web?query=test
```

The referrer is https://swisscows.com/.