### PR TITLE
Remove gougou.com

### DIFF
--- a/SearchEngines.yml
+++ b/SearchEngines.yml
@@ -1178,13 +1178,6 @@ Google Video:
     params:
       - q
     backlink: 'search?q={k}&tbm=vid'
-GouGou:
-  -
-    urls:
-      - web.gougou.com
-    params:
-      - search
-    backlink: 'search?search={k}'
 GoYellow.de:
   -
     urls:


### PR DESCRIPTION
According to the internet archive this search engine had been closed down more than 10 years ago.
As it's very unlikely someone might want to analyze data that old, it should be safe to remove it.