### PR TITLE
Add the referrer of the Mastodon Android app

### DIFF
--- a/Socials.yml
+++ b/Socials.yml
@@ -127,7 +127,6 @@ LiveJournal:
   - livejournal.com
 
 Mastodon:
-  - org.joinmastodon.android
   - mastodon.social
   - mastodon.cloud
   - mastodon.technology
@@ -171,6 +170,7 @@ Mastodon:
   - mastodon.world
   - mastodon.nz
   - graphics.social
+  - org.joinmastodon.android
 
 MeinVZ:
   - meinvz.net

--- a/Socials.yml
+++ b/Socials.yml
@@ -127,6 +127,7 @@ LiveJournal:
   - livejournal.com
 
 Mastodon:
+  - org.joinmastodon.android
   - mastodon.social
   - mastodon.cloud
   - mastodon.technology


### PR DESCRIPTION
The Mastodon Android app sends org.joinmastodon.android as referrer to websites opened from the app:
https://github.com/mastodon/mastodon-android/releases/tag/v2.9.4